### PR TITLE
Fix panic during error returning if Dataset\Query couldn't have found 

### DIFF
--- a/src/server/dekart/query.go
+++ b/src/server/dekart/query.go
@@ -3,11 +3,12 @@ package dekart
 import (
 	"context"
 	"crypto/sha1"
+	"fmt"
+	"time"
+
 	"dekart/src/proto"
 	"dekart/src/server/job"
 	"dekart/src/server/user"
-	"fmt"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
@@ -32,7 +33,7 @@ func (s Server) CreateQuery(ctx context.Context, req *proto.CreateQueryRequest) 
 	if reportID == nil {
 		err := fmt.Errorf("dataset not found or permission not granted")
 		log.Warn().Err(err).Str("dataset_id", req.DatasetId).Send()
-		return nil, status.Error(codes.NotFound, err.Error())
+		return nil, status.Error(codes.NotFound, "Dataset not found or permission not granted")
 	}
 
 	id := newUUID()
@@ -220,7 +221,7 @@ func (s Server) RunQuery(ctx context.Context, req *proto.RunQueryRequest) (*prot
 	if reportID == "" {
 		err := fmt.Errorf("query not found id:%s", req.QueryId)
 		log.Warn().Err(err).Send()
-		return nil, status.Error(codes.NotFound, err.Error())
+		return nil, status.Error(codes.NotFound, "Query not found")
 	}
 
 	err = s.storeQuerySync(ctx, req.QueryId, req.QueryText, prevQuerySourceId)
@@ -285,7 +286,7 @@ func (s Server) CancelQuery(ctx context.Context, req *proto.CancelQueryRequest) 
 	}
 	if reportID == "" {
 		log.Warn().Str("QueryId", req.QueryId).Msg("Query not found")
-		return nil, status.Error(codes.NotFound, err.Error())
+		return nil, status.Errorf(codes.NotFound, "Query not found")
 	}
 
 	if ok := s.jobs.Cancel(req.QueryId); !ok {

--- a/src/server/dekart/query.go
+++ b/src/server/dekart/query.go
@@ -286,7 +286,7 @@ func (s Server) CancelQuery(ctx context.Context, req *proto.CancelQueryRequest) 
 	}
 	if reportID == "" {
 		log.Warn().Str("QueryId", req.QueryId).Msg("Query not found")
-		return nil, status.Errorf(codes.NotFound, "Query not found")
+		return nil, status.Error(codes.NotFound, "Query not found")
 	}
 
 	if ok := s.jobs.Cancel(req.QueryId); !ok {

--- a/src/server/dekart/query.go
+++ b/src/server/dekart/query.go
@@ -33,7 +33,7 @@ func (s Server) CreateQuery(ctx context.Context, req *proto.CreateQueryRequest) 
 	if reportID == nil {
 		err := fmt.Errorf("dataset not found or permission not granted")
 		log.Warn().Err(err).Str("dataset_id", req.DatasetId).Send()
-		return nil, status.Error(codes.NotFound, "Dataset not found or permission not granted")
+		return nil, status.Error(codes.NotFound, err.Error())
 	}
 
 	id := newUUID()

--- a/src/server/dekart/query.go
+++ b/src/server/dekart/query.go
@@ -221,7 +221,7 @@ func (s Server) RunQuery(ctx context.Context, req *proto.RunQueryRequest) (*prot
 	if reportID == "" {
 		err := fmt.Errorf("query not found id:%s", req.QueryId)
 		log.Warn().Err(err).Send()
-		return nil, status.Error(codes.NotFound, "Query not found")
+		return nil, status.Error(codes.NotFound, err.Error())
 	}
 
 	err = s.storeQuerySync(ctx, req.QueryId, req.QueryText, prevQuerySourceId)
@@ -285,8 +285,9 @@ func (s Server) CancelQuery(ctx context.Context, req *proto.CancelQueryRequest) 
 		}
 	}
 	if reportID == "" {
+		err := fmt.Errorf("query not found id:%s", req.QueryId)
 		log.Warn().Str("QueryId", req.QueryId).Msg("Query not found")
-		return nil, status.Error(codes.NotFound, "Query not found")
+		return nil, status.Error(codes.NotFound, err.Error())
 	}
 
 	if ok := s.jobs.Cancel(req.QueryId); !ok {

--- a/src/server/user/claims.go
+++ b/src/server/user/claims.go
@@ -86,9 +86,14 @@ func (c ClaimsCheck) GetContext(r *http.Request) context.Context {
 	return userCtx
 }
 
-//GetClaims from the context
+// GetClaims from the context
 func GetClaims(ctx context.Context) *Claims {
-	return ctx.Value(contextKey).(*Claims)
+	value, isExist := ctx.Value(contextKey).(*Claims)
+	if isExist {
+		return value
+	}
+
+	return nil
 }
 
 func (c ClaimsCheck) getPublicKeyFromAmazon(token *jwt.Token) (interface{}, error) {


### PR DESCRIPTION
the application panics when couldn't find a query. at this point, it returns  `return nil, status.Error(codes.NotFound, err.Error())`. but here `err` is nil because 2 lines above we check that
```if err != nil {
		log.Err(err).Send()
		return nil, status.Error(codes.Internal, err.Error())
	}
```
just couldn't find a Dataset\Query

I just deleted panic cause (`err.Error()`) and added just a message 