### PR TITLE
add stacktrace and caller to logger

### DIFF
--- a/src/server/main.go
+++ b/src/server/main.go
@@ -24,12 +24,14 @@ import (
 	_ "github.com/lib/pq"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+	"github.com/rs/zerolog/pkgerrors"
 )
 
 func configureLogger() {
 	rand.Seed(time.Now().UnixNano())
 	zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
 	zerolog.ErrorStackFieldName = "stacktrace"
+	zerolog.ErrorStackMarshaler = pkgerrors.MarshalStack
 
 	pretty := os.Getenv("DEKART_LOG_PRETTY")
 	if pretty != "" {

--- a/src/server/main.go
+++ b/src/server/main.go
@@ -3,12 +3,6 @@ package main
 import (
 	"context"
 	"database/sql"
-	"dekart/src/server/app"
-	"dekart/src/server/athenajob"
-	"dekart/src/server/bqjob"
-	"dekart/src/server/dekart"
-	"dekart/src/server/job"
-	"dekart/src/server/storage"
 	"fmt"
 	"math/rand"
 	"net/http"
@@ -18,6 +12,12 @@ import (
 	"syscall"
 	"time"
 
+	"dekart/src/server/app"
+	"dekart/src/server/athenajob"
+	"dekart/src/server/bqjob"
+	"dekart/src/server/dekart"
+	"dekart/src/server/job"
+	"dekart/src/server/storage"
 	"github.com/golang-migrate/migrate/v4"
 	"github.com/golang-migrate/migrate/v4/database/postgres"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
@@ -29,10 +29,13 @@ import (
 func configureLogger() {
 	rand.Seed(time.Now().UnixNano())
 	zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
+	zerolog.ErrorStackFieldName = "stacktrace"
 
 	pretty := os.Getenv("DEKART_LOG_PRETTY")
 	if pretty != "" {
 		log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: time.RFC3339}).With().Caller().Logger()
+	} else {
+		log.Logger = log.Logger.With().Caller().Stack().Logger()
 	}
 
 	debug := os.Getenv("DEKART_LOG_DEBUG")


### PR DESCRIPTION
## Why
sometimes it's hard to clarify which line of code produces a message. I added `stacktrace` and `caller` fields to the logger. 
 
`caller`  field will be included in the message each time. it shows a line of the code like `/src/server/main.go:144`
`stacktrace` include this field when an error has been passed. Restrictions: Only using `github.com/pkg/errors`, you can add a formatted stacktrace to your errors.


