### PR TITLE
#15 fix incorrect decoding to csv

### DIFF
--- a/src/server/bqjob/decoder.go
+++ b/src/server/bqjob/decoder.go
@@ -52,7 +52,7 @@ func (d *Decoder) DecodeRows(undecoded []byte, csvRows chan []string) error {
 			err = fmt.Errorf("cannot convert datum to map")
 			return err
 		}
-		//TODO: create once?
+		// TODO: create once?
 		csvRow := make([]string, len(d.tableFields))
 		for i, name := range d.tableFields {
 			value := valuesMap[name]
@@ -60,14 +60,21 @@ func (d *Decoder) DecodeRows(undecoded []byte, csvRows chan []string) error {
 				csvRow[i] = ""
 				continue
 			}
-			valueMap, ok := value.(map[string]interface{})
-			if !ok {
-				err = fmt.Errorf("cannot convert value to map: value %+v", value)
-				return err
-			}
-			for _, v := range valueMap {
-				csvRow[i] = fmt.Sprintf("%v", v)
-				break
+
+			switch x := value.(type) {
+			case map[string]interface{}:
+				for _, v := range x {
+					csvRow[i] = fmt.Sprintf("%v", v)
+					break
+				}
+			case []interface{}:
+				csvRow[i] = fmt.Sprintf("%v", x)
+			case interface{}:
+				csvRow[i] = fmt.Sprintf("%v", x)
+			case nil:
+				csvRow[i] = ""
+			default:
+				return fmt.Errorf("incorrect type of data: %T", x)
 			}
 		}
 		csvRows <- csvRow


### PR DESCRIPTION
input data from issie #15 has a h3 that actually is a big string array
```
with zipcode_geom as (
    SELECT
        ST_GEOGFROMTEXT(zipcode_geom) as geom,
        bqcarto.h3.ST_ASH3_POLYFILL(ST_GEOGFROMTEXT(zipcode_geom), 10) as h3,
        zipcode
    FROM `bigquery-public-data.utility_us.zipcode_area`
    WHERE city = 'Seattle city' and zipcode='98105'
)

select
 ARRAY_LENGTH(h3),
 *
FROM zipcode_geom
```
BQ decoder returns decoded data like `map[string]interface{}` in most cases, but in the current case, it returns as a string array for the **h3** column.  in line of 65 we return an error when couldn't cast to map, instead of that I added a type checker that added to the column any data like an array or just an interface. 
Added the pic to make to more clear
![image](https://user-images.githubusercontent.com/11369612/210897914-9bb3972c-f0c4-4d9e-9dc2-156fe1ad0f2a.png)

##
Btw, in Google chrome, the column is seen, but in Safari isn't. I think it should be another issue
proofs 
<img width="1252" alt="image" src="https://user-images.githubusercontent.com/11369612/210898552-d603f4db-c1d7-48e0-afbe-114701ca3e7a.png">



 