### PR TITLE
Give ability to run BQ scripts on Dekart

### DIFF
--- a/src/server/bqjob/job.go
+++ b/src/server/bqjob/job.go
@@ -151,6 +151,11 @@ func (job *Job) GetResultTableForScript() (*bigquery.Table, error){
 	}
 
 	cfg, err := jobFromJobId.Config()
+
+	if err != nil{
+		return nil, err
+	}
+
 	queryConfig := cfg.(*bigquery.QueryConfig)
 
 	table := queryConfig.Dst

--- a/src/server/bqjob/job.go
+++ b/src/server/bqjob/job.go
@@ -156,7 +156,12 @@ func (job *Job) GetResultTableForScript() (*bigquery.Table, error){
 		return nil, err
 	}
 
-	queryConfig := cfg.(*bigquery.QueryConfig)
+	queryConfig, ok := cfg.(*bigquery.QueryConfig)
+	if !ok{
+		err := fmt.Errorf("was expecting QueryConfig type for configuration")
+		job.Logger.Error().Err(err).Str("jobConfig", fmt.Sprintf("%v+", cfg)).Send()
+		return nil, err
+	}
 
 	table := queryConfig.Dst
 

--- a/src/server/bqjob/job.go
+++ b/src/server/bqjob/job.go
@@ -24,6 +24,7 @@ type Job struct {
 	storageObject       storage.StorageObject
 	maxReadStreamsCount int32
 	maxBytesBilled      int64
+	client 				*bigquery.Client
 }
 
 var contextCancelledRe = regexp.MustCompile(`context canceled`)
@@ -142,10 +143,9 @@ func (job *Job) getResultTable() (*bigquery.Table, error) {
 
 func (job *Job) GetResultTableForScript() (*bigquery.Table, error){
 
-	client, err := bigquery.NewClient(job.GetCtx(), os.Getenv("DEKART_BIGQUERY_PROJECT_ID"))
 
 
-	jobFromJobId, err := client.JobFromID(job.GetCtx(), job.bigqueryJob.ID())
+	jobFromJobId, err := job.client.JobFromID(job.GetCtx(), job.bigqueryJob.ID())
 	if err != nil{
 		return nil, err
 	}
@@ -254,6 +254,8 @@ func (job *Job) Run(storageObject storage.StorageObject) error {
 		job.Cancel()
 		return err
 	}
+	job.client = client
+
 	query := client.Query(job.QueryText)
 	query.MaxBytesBilled = job.maxBytesBilled
 


### PR DESCRIPTION
The current implementation of getting data from the query fails because there is no Dst field on the job when the script is running, using this code, Dekart should have the ability to retrieve the final table of a script using the job id. 