### PR TITLE
Integrate kepler export button

### DIFF
--- a/src/client/ReportPage.module.css
+++ b/src/client/ReportPage.module.css
@@ -132,10 +132,6 @@
     background-color: #15232F;
 }
 
-.keplerBlock :global #kepler-gl__kepler .side-panel__header__top {
-    display: none;
-}
-
 .keplerBlock :global #kepler-gl__kepler .add-data-button {
     display: none;
 }


### PR DESCRIPTION
resolves #31 

The current view does not have the Kepler logo and export options on the header of the pannel; this change would allow users to use the export button. 
![kepler](https://user-images.githubusercontent.com/34164453/221251993-25595fa8-0f10-4b75-a58d-6dc38149e942.png)
