### PR TITLE
Configure database via `DEKART_POSTGRES_URL`

### DIFF
--- a/src/server/main.go
+++ b/src/server/main.go
@@ -53,14 +53,18 @@ func configureLogger() {
 }
 
 func configureDb() *sql.DB {
-	db, err := sql.Open("postgres", fmt.Sprintf(
-		"postgres://%s:%s@%s:%s/%s?sslmode=disable",
-		os.Getenv("DEKART_POSTGRES_USER"),
-		os.Getenv("DEKART_POSTGRES_PASSWORD"),
-		os.Getenv("DEKART_POSTGRES_HOST"),
-		os.Getenv("DEKART_POSTGRES_PORT"),
-		os.Getenv("DEKART_POSTGRES_DB"),
-	))
+	url, ok := os.LookupEnv("DEKART_POSTGRES_URL")
+	if !ok {
+		url = fmt.Sprintf(
+			"postgres://%s:%s@%s:%s/%s?sslmode=disable",
+			os.Getenv("DEKART_POSTGRES_USER"),
+			os.Getenv("DEKART_POSTGRES_PASSWORD"),
+			os.Getenv("DEKART_POSTGRES_HOST"),
+			os.Getenv("DEKART_POSTGRES_PORT"),
+			os.Getenv("DEKART_POSTGRES_DB"),
+		)
+	}
+	db, err := sql.Open("postgres", url)
 	if err != nil {
 		log.Fatal().Err(err).Send()
 	}


### PR DESCRIPTION
Added an option to configure PostgreSQL by passing the connection string as an environment variable. 

e.g. 
```
DEKART_POSTGRES_URL=postgres://user:pass@hostname:5432/dekart?sslmode=verify-full
```

This would be an optional alternative to setting individual parameters under the `DEKART_POSTGRES_*` environment variables.

My motivation for making this change was to get Dekart working with a serverless Postgres instance from [Neon](https://neon.tech/), but having [`sslmode=disable`](https://github.com/dekart-xyz/dekart/blob/751d2c849725470d2a06510fc02f97d9efce99c0/src/server/main.go#LL57C29-L57C45) hardcoded in the connection string caused issues. By adding an option to provide the whole connection string via `DEKART_POSTGRES_URL` meant I could set `sslmode=verify-full` after which everything worked fine.