### PR TITLE
Fix makefile of install app-engine

### DIFF
--- a/install/app-engine/Makefile
+++ b/install/app-engine/Makefile
@@ -22,6 +22,7 @@ app-deploy:
 	PROJECT_ID=${PROJECT_ID} \
 	MAPBOX_TOKEN=${MAPBOX_TOKEN} \
 	CORS_ORIGIN=${CORS_ORIGIN} \
+	DB_INSTANCE_NAME=${DB_INSTANCE_NAME} \
 	envsubst < app.example.yaml > app.yaml
 	gcloud app deploy app.yaml
 


### PR DESCRIPTION
Hi.

Fix issue.
Fixed missing argument DB_INSTANCE_NAME when deploying with app engine in make command.

Please check if you like.