### PR TITLE
Allow Athena queries in QUEUED status to continue

### DIFF
--- a/src/server/athenajob/athenajob.go
+++ b/src/server/athenajob/athenajob.go
@@ -91,7 +91,7 @@ func (j *Job) pullQueryExecutionStatus() (*athena.QueryExecution, error) {
 			}
 			status := *out.QueryExecution.Status.State
 			switch status {
-			case "RUNNING":
+			case "RUNNING", "QUEUED":
 				continue
 			case "SUCCEEDED":
 				return out.QueryExecution, nil


### PR DESCRIPTION
AWS Athena queries have a state `QUEUED` that isn't an error state, but indicates that the query is pending processing before actually running. 

Source: https://github.com/aws/aws-sdk-go/blob/8d203ccff393340d080be0417d091cc60354449b/service/athena/api.go#L14790-L14799

This change allows the query to continue to run, rather than show an error message:

![Screenshot 2025-03-12 at 4 08 51 PM](https://github.com/user-attachments/assets/08dedd72-084b-4f2a-9d3e-2d721284de7e)

I think the change is straightforward, but let me know if any changes are requested.

## Contributor License Agreement

- [x] I hereby grant to the owners of this project repository a perpetual, worldwide, non-exclusive, royalty-free, irrevocable license to use, reproduce, modify, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute my contributions, in whole or in part, under any licenses, including the GNU Affero General Public License (AGPL) v3.0 and a [Commercial License](https://dekart.xyz/legal/dekart-premium-terms/).
