### PR TITLE
Allow Athena connections to upload files

### DIFF
--- a/src/server/dekart/connection.go
+++ b/src/server/dekart/connection.go
@@ -144,6 +144,7 @@ func (s Server) getConnection(ctx context.Context, connectionID string) (*proto.
 		case "ATHENA":
 			con.ConnectionType = proto.ConnectionType_CONNECTION_TYPE_ATHENA
 			con.ConnectionName = "Athena"
+			con.CloudStorageBucket = storage.GetDefaultBucketName()
 		case "PG":
 			con.ConnectionType = proto.ConnectionType_CONNECTION_TYPE_POSTGRES
 			con.ConnectionName = "Postgres"


### PR DESCRIPTION
Appears that in #247, Athena connections lost the ability to upload files due to how `con.CanStoreFiles` was defined in `src/server/dekart/connection.go`. This change brings it back, testing locally confirmed the fix for me.

## Contributor License Agreement

- [x] I hereby grant to the owners of this project repository a perpetual, worldwide, non-exclusive, royalty-free, irrevocable license to use, reproduce, modify, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute my contributions, in whole or in part, under any licenses, including the GNU Affero General Public License (AGPL) v3.0 and a [Commercial License](https://dekart.xyz/legal/dekart-premium-terms/).
