### PR TITLE
Refactor Query component and enhance keyboard shortcuts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,50 +26,15 @@ Self-check before finalizing:
 - Follow existing project conventions before introducing new patterns.
 - Prefer established libraries for standard concerns over custom implementations.
 - Use canonical state, not ad-hoc component logic: before deriving behavior in components, check reducers/actions/selectors for an existing field and reuse it; if missing, add it once in the state layer (reducer/selector) and consume that everywhere.
+- When extending a function that is already over 50 lines, refactor to keep functions under 50 lines using the smallest elegant extraction needed; preserve existing behavior and avoid broad rewrites.
+- Add a short purpose description for each new function.
+- For each non-trivial business-logic block (especially complex conditions), add a very short `why` comment.
 - Do not use debug-level logging in production code paths.
 - Keep test structure consistent with neighboring tests in the same folder.
 - Match existing UI patterns and placement
 - Validate behavior end-to-end in the real runtime path before finalizing.
 
-## Release Notes Skill (Mandatory when writing release notes)
+## Skills (Mandatory)
 
-When asked to produce release notes, follow this structure and filtering:
-
-- Use `docs/release-notes-0-21-0.md` as the formatting template and section style baseline.
-- Present items in this exact order:
-  1. User-facing features first.
-  2. Changes important for admins/operators second.
-  3. User-facing bug fixes third.
-  4. Upgrade instructions last.
-- Skip chore/internal-only changes that do not affect users or admins (for example CI/workflow-only changes).
-- Keep language outcome-focused (what changed for users/admins), not implementation-heavy.
-- Include only changes in the requested version/tag diff range.
-
-# Runbook
-
-## Cypress Quick Start
-
-Run from repo root:
-
-```bash
-ELECTRON_RUN_AS_NODE= npx cypress run --spec "cypress/e2e/snowflake-s3/layerOrderRerunRegression.cy.js"
-```
-
-Why: this environment exports `ELECTRON_RUN_AS_NODE=1` by default, which prevents Cypress from starting. Prefixing with `ELECTRON_RUN_AS_NODE=` unsets it for the command.
-
-## Common Cypress Commands
-
-- Run one spec:
-  - `ELECTRON_RUN_AS_NODE= npx cypress run --spec "cypress/e2e/snowflake-s3/layerOrderRerunRegression.cy.js"`
-- Run all Snowflake S3 specs:
-  - `ELECTRON_RUN_AS_NODE= npx cypress run --spec "cypress/e2e/snowflake-s3/*.cy.js"`
-- Open interactive Cypress app:
-  - `ELECTRON_RUN_AS_NODE= npx cypress open`
-
-## If Cypress Fails To Start
-
-1. Install Cypress binary:
-   - `npx cypress install`
-2. Re-run with env override:
-   - `ELECTRON_RUN_AS_NODE= npx cypress run --spec "<spec-path>"`
-
+- For release notes tasks, use [skills/release-notes/SKILL.md](/Users/vladi/dev/dekart/skills/release-notes/SKILL.md).
+- For Cypress execution in this repo, use [skills/cypress-quick-start/SKILL.md](/Users/vladi/dev/dekart/skills/cypress-quick-start/SKILL.md).

--- a/skills/cypress-quick-start/SKILL.md
+++ b/skills/cypress-quick-start/SKILL.md
@@ -1,0 +1,31 @@
+# Cypress Quick Start Skill
+
+## Trigger
+
+Use this skill when asked to run Cypress tests in this repository.
+
+## Quick Start
+
+Run from repo root:
+
+```bash
+ELECTRON_RUN_AS_NODE= npx cypress run --spec "cypress/e2e/snowflake-s3/layerOrderRerunRegression.cy.js"
+```
+
+Why: this environment exports `ELECTRON_RUN_AS_NODE=1` by default, which prevents Cypress from starting. Prefixing with `ELECTRON_RUN_AS_NODE=` unsets it for the command.
+
+## Common Commands
+
+- Run one spec:
+  - `ELECTRON_RUN_AS_NODE= npx cypress run --spec "cypress/e2e/snowflake-s3/layerOrderRerunRegression.cy.js"`
+- Run all Snowflake S3 specs:
+  - `ELECTRON_RUN_AS_NODE= npx cypress run --spec "cypress/e2e/snowflake-s3/*.cy.js"`
+- Open interactive Cypress app:
+  - `ELECTRON_RUN_AS_NODE= npx cypress open`
+
+## If Cypress Fails To Start
+
+1. Install Cypress binary:
+   - `npx cypress install`
+2. Re-run with env override:
+   - `ELECTRON_RUN_AS_NODE= npx cypress run --spec "<spec-path>"`

--- a/skills/release-notes/SKILL.md
+++ b/skills/release-notes/SKILL.md
@@ -1,0 +1,17 @@
+# Release Notes Skill
+
+## Trigger
+
+Use this skill when asked to write release notes.
+
+## Instructions
+
+- Use `docs/release-notes-0-21-0.md` as the formatting template and section style baseline.
+- Present items in this exact order:
+  1. User-facing features first.
+  2. Changes important for admins/operators second.
+  3. User-facing bug fixes third.
+  4. Upgrade instructions last.
+- Skip chore/internal-only changes that do not affect users or admins (for example CI/workflow-only changes).
+- Keep language outcome-focused (what changed for users/admins), not implementation-heavy.
+- Include only changes in the requested version/tag diff range.

--- a/src/client/Query.jsx
+++ b/src/client/Query.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import AceEditor from 'react-ace'
 import { AutoSizer } from 'react-virtualized'
 import Button from 'antd/es/button'
@@ -15,6 +15,8 @@ import { SendOutlined, CheckCircleTwoTone, ExclamationCircleTwoTone, ClockCircle
 import { Duration } from 'luxon'
 import DataDocumentationLink from './DataDocumentationLink'
 import { cancelJob, queryChanged, runQuery } from './actions/query'
+import { setActiveDataset } from './actions/dataset'
+import { showReadmeTab } from './actions/readme'
 import Tooltip from 'antd/es/tooltip'
 import { getDatasourceMeta } from './lib/datasource'
 import { copyErrorToClipboard } from './actions/clipboard'
@@ -67,17 +69,132 @@ function StatusActions ({ queryJob }) {
   )
 }
 
-function QueryEditor ({ queryId, queryText, onChange, canWrite }) {
+// Parse editor-local tab shortcut: Ctrl+Shift+[1..9] -> 0-based tab index.
+function getEditorTabShortcutIndex (event) {
+  const hasRequiredModifiers = event.ctrlKey && event.shiftKey && !event.metaKey && !event.altKey
+  if (!hasRequiredModifiers) {
+    return null
+  }
+  const match = event.code && event.code.match(/^Digit([1-9])$/)
+  if (!match) {
+    return null
+  }
+  return Number(match[1]) - 1
+}
+
+// Build tab keys in the same order as report tabs.
+function getShortcutTabKeys (reportReadme, datasets) {
+  const keys = []
+  if (reportReadme) {
+    keys.push('readme')
+  }
+  return keys.concat(datasets.map(dataset => dataset.id))
+}
+
+// Switch tab from editor shortcut using Redux actions only.
+function switchTabFromEditorShortcut ({ tabIndex, reportReadme, datasets, dispatch }) {
+  const tabKeys = getShortcutTabKeys(reportReadme, datasets)
+  const tabKey = tabKeys[tabIndex]
+  if (!tabKey) {
+    return
+  }
+  if (tabKey === 'readme') {
+    dispatch(showReadmeTab())
+    return
+  }
+  dispatch(setActiveDataset(tabKey))
+}
+
+// Intercept shortcuts before Ace keybindings, so behavior is deterministic.
+function registerQueryEditorKeyboardInterceptors ({ editor, getCanExecute, executeQuery, switchTab }) {
+  editor.container.addEventListener('keydown', (event) => {
+    const tabIndex = getEditorTabShortcutIndex(event)
+    if (tabIndex !== null) {
+      event.preventDefault()
+      event.stopPropagation()
+      switchTab(tabIndex)
+      return
+    }
+
+    const isRunShortcut = (event.metaKey || event.ctrlKey) && event.key === 'Enter'
+    if (!isRunShortcut) {
+      return
+    }
+    event.preventDefault()
+    event.stopPropagation()
+    if (!getCanExecute()) {
+      return
+    }
+    executeQuery()
+  }, true)
+}
+
+// Focus Ace editor input when query tab becomes active.
+function focusAceEditor (editor) {
+  if (!editor || typeof editor.focus !== 'function') {
+    return
+  }
+  setTimeout(() => {
+    editor.focus()
+  }, 0)
+}
+
+function QueryEditor ({ queryId, queryText, onChange, canWrite, canExecute, onExecute }) {
   const dataset = useSelector(state => state.dataset.list.find(q => q.queryId === queryId))
+  const datasets = useSelector(state => state.dataset.list)
   const connection = useSelector(state => state.connection.list.find(c => c.id === dataset?.connectionId))
+  const reportReadme = useSelector(state => state.report.readme)
   const connectionType = useConnectionType(connection?.id)
   const completer = getDatasourceMeta(connectionType)?.completer
+  const dispatch = useDispatch()
+  const datasetsRef = useRef(datasets)
+  const reportReadmeRef = useRef(reportReadme)
+  const canExecuteRef = useRef(canExecute)
+  const onExecuteRef = useRef(onExecute)
+  const editorRef = useRef(null)
+
+  useEffect(() => {
+    datasetsRef.current = datasets
+  }, [datasets])
+
+  useEffect(() => {
+    reportReadmeRef.current = reportReadme
+  }, [reportReadme])
+
+  useEffect(() => {
+    canExecuteRef.current = canExecute
+  }, [canExecute])
+
+  useEffect(() => {
+    onExecuteRef.current = onExecute
+  }, [onExecute])
+
   useEffect(() => {
     if (completer) {
       const langTools = window.ace.require('ace/ext/language_tools')
       langTools.addCompleter(completer)
     }
   }, [completer])
+
+  const onEditorLoad = useCallback((editor) => {
+    editorRef.current = editor
+    registerQueryEditorKeyboardInterceptors({
+      editor,
+      getCanExecute: () => canExecuteRef.current,
+      executeQuery: () => onExecuteRef.current(),
+      switchTab: (tabIndex) => switchTabFromEditorShortcut({
+        tabIndex,
+        reportReadme: reportReadmeRef.current,
+        datasets: datasetsRef.current,
+        dispatch
+      })
+    })
+    focusAceEditor(editor)
+  }, [dispatch])
+
+  useEffect(() => {
+    focusAceEditor(editorRef.current)
+  }, [queryId])
 
   return (
     <div className={styles.editor}>
@@ -91,6 +208,7 @@ function QueryEditor ({ queryId, queryText, onChange, canWrite }) {
             name={'AceEditor' + queryId}
             keyboardHandler='vscode'
             onChange={onChange}
+            onLoad={onEditorLoad}
             value={queryText}
             readOnly={!canWrite}
             editorProps={{ $blockScrolling: true }}
@@ -294,6 +412,12 @@ export default function Query ({ query }) {
   const { canWrite } = useSelector(state => state.report)
   const edit = useSelector(state => state.reportStatus.edit)
   const dispatch = useDispatch()
+  const canExecute = canWrite && edit && canRun && queryText
+  const executeQuery = useCallback(() => {
+    track('QueryExecute', { queryId: query.id })
+    dispatch(runQuery(query.id, queryText))
+  }, [dispatch, query.id, queryText])
+
   return (
     <div key={query.id} className={styles.query}>
       <QueryEditor
@@ -301,19 +425,20 @@ export default function Query ({ query }) {
         queryText={queryText}
         onChange={value => dispatch(queryChanged(query.id, value))}
         canWrite={canWrite && edit}
+        canExecute={canExecute}
+        onExecute={executeQuery}
       />
       <QueryStatus query={query}>
         {
           canWrite && edit
             ? (
               <Button
+                id='dekart-query-execute-button'
                 size='large'
-                disabled={!canRun || !queryText}
+                disabled={!canExecute}
                 icon={<SendOutlined />}
-                onClick={() => {
-                  track('QueryExecute', { queryId: query.id })
-                  dispatch(runQuery(query.id, queryText))
-                }}
+                title='Execute query (Cmd/Ctrl+Enter)'
+                onClick={executeQuery}
               >Execute
               </Button>
               )

--- a/src/client/ReportPage.jsx
+++ b/src/client/ReportPage.jsx
@@ -37,6 +37,14 @@ import { getDefaultMapStyles } from '@kepler.gl/reducers'
 import { getApplicationConfig } from '@kepler.gl/utils'
 import UserPositionOverlay from './UserPositionOverlay'
 
+// Build keyboard hint text for tab tooltips.
+function getTabShortcutLabel (tabIndex) {
+  if (tabIndex < 0 || tabIndex > 8) {
+    return null
+  }
+  return `In editor: Ctrl+Shift+${tabIndex + 1}`
+}
+
 function TabIcon ({ job }) {
   let iconColor = 'transparent'
   if (job.jobError) {
@@ -128,11 +136,12 @@ function QueryTooltip ({ job, dataset }) {
   )
 }
 
-function getTabPane (dataset, queries, files, status, queryJobs, closable, lastDataset) {
+function getTabPane (dataset, queries, files, status, queryJobs, closable, lastDataset, tabIndex) {
   let changed = false
   const title = getDatasetName(dataset, queries, files)
   let tabIcon = null
   let tooltip = null
+  const shortcutLabel = getTabShortcutLabel(tabIndex)
   if (dataset.queryId) {
     const job = queryJobs.find(j => j.queryId === dataset.queryId)
     if (job) {
@@ -148,7 +157,18 @@ function getTabPane (dataset, queries, files, status, queryJobs, closable, lastD
   }
   return (
     <Tabs.TabPane
-      tab={<Tooltip placement='bottom' title={tooltip}>{tabIcon}{tabTitle}</Tooltip>}
+      tab={
+        <Tooltip
+          placement='bottom'
+          title={
+            <span className={styles.queryTooltip}>
+              {shortcutLabel ? <span>{shortcutLabel}</span> : null}
+              {tooltip}
+            </span>
+          }
+        >{tabIcon}{tabTitle}
+        </Tooltip>
+      }
       key={dataset.id}
       closable={Boolean((closable && !lastDataset) || closeIcon)}
       closeIcon={closeIcon}
@@ -176,13 +196,16 @@ function DatasetSection ({ reportId }) {
   const disableSQL = !report.allowExport && !report.canWrite
 
   if (report.readme) {
+    const readmeShortcut = getTabShortcutLabel(0)
     readmeTab.push(
       <Tabs.TabPane
         className={styles.addTabPane}
         tab={
-          <>
-            <ReadOutlined /> Readme
-          </>
+          <Tooltip placement='bottom' title={readmeShortcut ? <span>{readmeShortcut}</span> : null}>
+            <>
+              <ReadOutlined /> Readme
+            </>
+          </Tooltip>
         }
         key='readme'
         closable={canWrite && edit}
@@ -233,7 +256,16 @@ function DatasetSection ({ reportId }) {
                   hideAdd={!(canWrite && edit)}
                   onEdit={getOnTabEditHandler(dispatch, reportId, datasets)}
                 >
-                  {readmeTab.concat(datasets.map((dataset) => getTabPane(dataset, queries, files, queryStatus, queryJobs, closable, lastDataset)))}
+                  {readmeTab.concat(datasets.map((dataset, index) => getTabPane(
+                    dataset,
+                    queries,
+                    files,
+                    queryStatus,
+                    queryJobs,
+                    closable,
+                    lastDataset,
+                    index + (report.readme ? 1 : 0)
+                  )))}
                 </Tabs>
               </div>
               {showReadme ? <Readme readme={report.readme} /> : <Dataset dataset={activeDataset} />}


### PR DESCRIPTION
- Introduced keyboard shortcuts for tab navigation in the Query editor, allowing users to switch tabs using Ctrl+Shift+[1..9].
- Added functionality to focus the Ace editor when a query tab becomes active.

## Contributor License Agreement

- [X] I hereby grant to the owners of this project repository a perpetual, worldwide, non-exclusive, royalty-free, irrevocable license to use, reproduce, modify, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute my contributions, in whole or in part, under any licenses, including the GNU Affero General Public License (AGPL) v3.0 and a [Commercial License](https://dekart.xyz/legal/dekart-premium-terms/).
