### PR TITLE
Enhance SQLite backup functionality and add Snowflake stage object na…

### DIFF
--- a/src/server/dekart/backup.go
+++ b/src/server/dekart/backup.go
@@ -2,6 +2,7 @@ package dekart
 
 import (
 	"context"
+	"crypto/sha256"
 	"dekart/src/server/storage"
 	"fmt"
 	"io"
@@ -24,6 +25,8 @@ const (
 	backupTargetObjectStorage  sqliteBackupTarget = "object_storage"
 	defaultBackupFrequencyMin                     = 5
 	defaultMaxBackupsAgeDays                      = 7
+	defaultBackupPruneInterval                    = 24 * time.Hour
+	defaultBackupPruneLimit                       = 1000
 )
 
 func getBackupTarget() sqliteBackupTarget {
@@ -42,9 +45,21 @@ func sqliteBackupObjectPrefix() string {
 	return "sqlite-backups/"
 }
 
-func sqliteBackupObjectName(ts time.Time) string {
+// sqliteBackupObjectPrefixForTarget keeps Snowflake stage backups at root for Native App compatibility.
+func sqliteBackupObjectPrefixForTarget(target sqliteBackupTarget) string {
+	if target == backupTargetSnowflakeStage {
+		return filepath.Base(os.Getenv("DEKART_SQLITE_DB_PATH")) + "_"
+	}
+	return sqliteBackupObjectPrefix()
+}
+
+func sqliteBackupObjectName(ts time.Time, target sqliteBackupTarget) string {
 	dbFileName := filepath.Base(os.Getenv("DEKART_SQLITE_DB_PATH"))
-	return sqliteBackupObjectPrefix() + fmt.Sprintf("%s_%s.backup", dbFileName, ts.UTC().Format("20060102_150405"))
+	name := fmt.Sprintf("%s_%s.backup", dbFileName, ts.UTC().Format("20060102_150405"))
+	if target == backupTargetSnowflakeStage {
+		return name
+	}
+	return sqliteBackupObjectPrefix() + name
 }
 
 func parseBackupTimestamp(name string) (time.Time, bool) {
@@ -145,16 +160,59 @@ func RestoreDbFile() {
 		return
 	}
 
-	restoreFromStorage(dbFilePath, st, location)
+	restoreFromStorage(dbFilePath, st, location, target)
 }
 
 // BackupLock struct with a mutex and a boolean flag
 type BackupLock struct {
-	mutex     sync.Mutex
-	isRunning bool
+	mutex              sync.Mutex
+	isRunning          bool
+	hasLastFingerprint bool
+	lastFingerprint    sqliteBackupFingerprint
+	lastPruneAt        time.Time
 }
 
 var bl BackupLock = BackupLock{}
+
+type sqliteBackupFingerprint struct {
+	hash [sha256.Size]byte
+}
+
+// sqliteBackupFingerprintForPath hashes SQLite storage files to skip duplicate backups.
+func sqliteBackupFingerprintForPath(path string) (sqliteBackupFingerprint, error) {
+	h := sha256.New()
+	for _, fingerprintPath := range sqliteFingerprintPaths(path) {
+		if err := appendFileFingerprint(h, fingerprintPath); err != nil {
+			return sqliteBackupFingerprint{}, err
+		}
+	}
+	var fingerprint sqliteBackupFingerprint
+	copy(fingerprint.hash[:], h.Sum(nil))
+	return fingerprint, nil
+}
+
+func sqliteFingerprintPaths(path string) []string {
+	return []string{path, path + "-wal", path + "-journal"}
+}
+
+func appendFileFingerprint(w io.Writer, path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			_, _ = fmt.Fprintf(w, "missing:%s\n", path)
+			return nil
+		}
+		return err
+	}
+	_, _ = fmt.Fprintf(w, "file:%s:%d\n", path, info.Size())
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = io.Copy(w, f)
+	return err
+}
 
 func (s Server) CreateBackup(deleteOld bool) {
 	if !isSQLiteEnabled() {
@@ -168,6 +226,7 @@ func (s Server) CreateBackup(deleteOld bool) {
 
 	dbFilePath := sqliteDBFilePath()
 
+	// Mark this invocation as running under lock so overlapping backup calls skip.
 	bl.mutex.Lock()
 	if bl.isRunning {
 		bl.mutex.Unlock()
@@ -175,33 +234,21 @@ func (s Server) CreateBackup(deleteOld bool) {
 		return
 	}
 	bl.isRunning = true
+	// Release before slow SQLite/storage work; the flag, not the mutex, guards overlap.
 	bl.mutex.Unlock()
 
+	// Always clear the running flag when this invocation exits.
 	defer func() {
 		bl.mutex.Lock()
 		bl.isRunning = false
 		bl.mutex.Unlock()
 	}()
 
-	ts := time.Now().UTC()
-	backupPath := fmt.Sprintf("%s_%s.backup", dbFilePath, ts.Format("20060102_150405"))
-	if _, err := s.db.Exec(`VACUUM INTO $1`, backupPath); err != nil {
-		log.Fatal().Err(err).Msg("Failed to create backup")
+	fingerprint, err := sqliteBackupFingerprintForPath(dbFilePath)
+	if err != nil {
+		log.Fatal().Err(err).Str("db_file_path", dbFilePath).Msg("Failed to check SQLite database file")
 	}
 
-	switch target {
-	case backupTargetObjectStorage:
-		uploadBackupToStorage(backupPath, ts, deleteOld, target)
-	case backupTargetSnowflakeStage:
-		uploadBackupToStorage(backupPath, ts, deleteOld, target)
-	}
-
-	if err := os.Remove(backupPath); err != nil {
-		log.Error().Err(err).Str("backup_path", backupPath).Msg("Failed to delete local backup file")
-	}
-}
-
-func uploadBackupToStorage(backupPath string, ts time.Time, deleteOld bool, target sqliteBackupTarget) {
 	ctx := context.Background()
 	st, location, ok := newBackupStorage(target)
 	if !ok {
@@ -209,49 +256,123 @@ func uploadBackupToStorage(backupPath string, ts time.Time, deleteOld bool, targ
 		return
 	}
 
-	objectName := sqliteBackupObjectName(ts)
-	if err := uploadBackupFile(ctx, st, location, objectName, backupPath); err != nil {
-		log.Error().Err(err).Str("location", location).Str("object", objectName).Msg("Failed to upload backup")
+	shouldUpload := !bl.hasLastFingerprint || bl.lastFingerprint != fingerprint
+	if !shouldUpload {
+		log.Info().Str("db_file_path", dbFilePath).Msg("SQLite backup skipped: database file unchanged")
+		if deleteOld {
+			pruneOldBackups(ctx, st, location, target)
+		}
 		return
 	}
-	log.Info().Str("backup_path", backupPath).Str("location", location).Str("object", objectName).Msg("Backup uploaded successfully")
 
+	ts := time.Now().UTC()
+	backupPath := fmt.Sprintf("%s_%s.backup", dbFilePath, ts.Format("20060102_150405"))
+	if _, err := s.db.Exec(`VACUUM INTO $1`, backupPath); err != nil {
+		log.Fatal().Err(err).Msg("Failed to create backup")
+	}
+
+	if uploadBackupToStorage(ctx, st, location, backupPath, ts, target) {
+		bl.hasLastFingerprint = true
+		bl.lastFingerprint = fingerprint
+	}
 	if deleteOld {
-		pruneOldBackups(ctx, st, location)
+		pruneOldBackups(ctx, st, location, target)
+	}
+
+	if err := os.Remove(backupPath); err != nil {
+		log.Error().Err(err).Str("backup_path", backupPath).Msg("Failed to delete local backup file")
 	}
 }
 
-func pruneOldBackups(ctx context.Context, st storage.Storage, location string) {
-	objects, err := st.ListObjectsByPrefix(ctx, location, sqliteBackupObjectPrefix())
+func uploadBackupToStorage(ctx context.Context, st storage.Storage, location string, backupPath string, ts time.Time, target sqliteBackupTarget) bool {
+	objectName := sqliteBackupObjectName(ts, target)
+	if err := uploadBackupFile(ctx, st, location, objectName, backupPath); err != nil {
+		log.Error().Err(err).Str("location", location).Str("object", objectName).Msg("Failed to upload backup")
+		return false
+	}
+	log.Info().Str("backup_path", backupPath).Str("location", location).Str("object", objectName).Msg("Backup uploaded successfully")
+	return true
+}
+
+func pruneOldBackups(ctx context.Context, st storage.Storage, location string, target sqliteBackupTarget) {
+	if !canPruneBackups(time.Now().UTC()) {
+		return
+	}
+	objects, err := listSQLiteBackupObjects(ctx, st, location, target)
 	if err != nil {
 		log.Error().Err(err).Str("location", location).Msg("Failed to list backup objects for prune")
 		return
 	}
 	maxAge := time.Now().Add(-time.Duration(maxBackupsAgeDays()) * 24 * time.Hour)
+	expired := make([]string, 0)
 	for _, obj := range objects {
 		backupTS, ok := parseBackupTimestamp(obj.Name)
 		if !ok {
 			continue
 		}
 		if backupTS.Before(maxAge) {
-			if err := st.GetObject(ctx, location, obj.Name).Delete(ctx); err != nil {
-				log.Error().Err(err).Str("location", location).Str("object", obj.Name).Msg("Failed to delete old backup object")
-			} else {
-				log.Info().Str("location", location).Str("object", obj.Name).Msg("Old backup object deleted")
+			expired = append(expired, obj.Name)
+			if len(expired) >= defaultBackupPruneLimit {
+				break
 			}
 		}
 	}
+	if deleteBackupObjects(ctx, st, location, expired) {
+		markBackupPruned(time.Now().UTC())
+	}
 }
 
-func restoreFromStorage(dbFilePath string, st storage.Storage, location string) {
+// canPruneBackups enforces the once-per-day cleanup budget in this process.
+func canPruneBackups(now time.Time) bool {
+	bl.mutex.Lock()
+	defer bl.mutex.Unlock()
+	if !bl.lastPruneAt.IsZero() && now.Sub(bl.lastPruneAt) < defaultBackupPruneInterval {
+		return false
+	}
+	return true
+}
+
+func markBackupPruned(now time.Time) {
+	bl.mutex.Lock()
+	bl.lastPruneAt = now
+	bl.mutex.Unlock()
+}
+
+// deleteBackupObjects deletes only the expired backup names selected by prune.
+func deleteBackupObjects(ctx context.Context, st storage.Storage, location string, names []string) bool {
+	if len(names) == 0 {
+		return true
+	}
+	ok := true
+	for _, name := range names {
+		if err := st.GetObject(ctx, location, name).Delete(ctx); err != nil {
+			log.Error().Err(err).Str("location", location).Str("object", name).Msg("Failed to delete old backup object")
+			ok = false
+		} else {
+			log.Info().Str("location", location).Str("object", name).Msg("Old backup object deleted")
+		}
+	}
+	return ok
+}
+
+// listSQLiteBackupObjects returns the active backup layout for the selected target.
+func listSQLiteBackupObjects(ctx context.Context, st storage.Storage, location string, target sqliteBackupTarget) ([]storage.ObjectInfo, error) {
+	prefix := sqliteBackupObjectPrefixForTarget(target)
+	if prefix == "" || prefix == "_" {
+		return nil, nil
+	}
+	return st.ListObjectsByPrefix(ctx, location, prefix)
+}
+
+func restoreFromStorage(dbFilePath string, st storage.Storage, location string, target sqliteBackupTarget) {
 	ctx := context.Background()
-	objects, err := st.ListObjectsByPrefix(ctx, location, sqliteBackupObjectPrefix())
+	objects, err := listSQLiteBackupObjects(ctx, st, location, target)
 	if err != nil {
 		log.Error().Err(err).Str("location", location).Msg("Failed to list backup objects")
 		return
 	}
 	if len(objects) == 0 {
-		log.Warn().Str("location", location).Str("prefix", sqliteBackupObjectPrefix()).Msg("No SQLite backup found")
+		log.Warn().Str("location", location).Msg("No SQLite backup found")
 		return
 	}
 

--- a/src/server/dekart/backup_test.go
+++ b/src/server/dekart/backup_test.go
@@ -1,79 +1,18 @@
 package dekart
 
 import (
-	"bytes"
 	"context"
-	"io"
 	"net/http"
 	"net/http/httptest"
-	"os"
-	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
 	"dekart/src/proto"
-	"dekart/src/server/storage"
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/gorilla/mux"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
-
-type backupTestStorage struct {
-	storage.UnsupportedUploadSessionStorage
-	objects map[string][]byte
-}
-
-type backupTestObject struct {
-	data []byte
-}
-
-func (s backupTestStorage) GetObject(_ context.Context, _, name string) storage.StorageObject {
-	return backupTestObject{data: s.objects[name]}
-}
-
-func (s backupTestStorage) ListObjectsByPrefix(_ context.Context, _, prefix string) ([]storage.ObjectInfo, error) {
-	objects := make([]storage.ObjectInfo, 0)
-	for name := range s.objects {
-		if strings.HasPrefix(name, prefix) {
-			objects = append(objects, storage.ObjectInfo{Name: name})
-		}
-	}
-	return objects, nil
-}
-
-func (backupTestStorage) CanSaveQuery(context.Context, string) bool {
-	return false
-}
-
-func (o backupTestObject) GetReader(context.Context) (io.ReadCloser, error) {
-	return io.NopCloser(bytes.NewReader(o.data)), nil
-}
-
-func (backupTestObject) GetWriter(context.Context) io.WriteCloser {
-	return nil
-}
-
-func (backupTestObject) GetCreatedAt(context.Context) (*time.Time, error) {
-	return nil, nil
-}
-
-func (backupTestObject) GetSize(context.Context) (*int64, error) {
-	return nil, nil
-}
-
-func (backupTestObject) CopyFromS3(context.Context, string) error {
-	return nil
-}
-
-func (backupTestObject) CopyTo(context.Context, io.WriteCloser) error {
-	return nil
-}
-
-func (backupTestObject) Delete(context.Context) error {
-	return nil
-}
 
 func TestGetBackupTargetUsesObjectStorageForBucketBackends(t *testing.T) {
 	for _, storageBackend := range []string{"S3", "GCS", "PG"} {
@@ -96,6 +35,18 @@ func TestGetBackupTargetDisablesPGWithoutBucket(t *testing.T) {
 
 	if got := getBackupTarget(); got != backupTargetDisabled {
 		t.Fatalf("expected disabled backup target, got %q", got)
+	}
+}
+
+func TestSQLiteBackupObjectNameUsesTargetLayout(t *testing.T) {
+	t.Setenv("DEKART_SQLITE_DB_PATH", "/data/dekart.db")
+	ts := time.Date(2026, 6, 29, 14, 57, 18, 0, time.UTC)
+
+	if got := sqliteBackupObjectName(ts, backupTargetSnowflakeStage); got != "dekart.db_20260629_145718.backup" {
+		t.Fatalf("expected Snowflake stage root backup, got %q", got)
+	}
+	if got := sqliteBackupObjectName(ts, backupTargetObjectStorage); got != "sqlite-backups/dekart.db_20260629_145718.backup" {
+		t.Fatalf("expected object storage prefixed backup, got %q", got)
 	}
 }
 
@@ -156,26 +107,5 @@ func TestServeMapPreviewUsesDefaultForPGBackupBucket(t *testing.T) {
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatal(err)
-	}
-}
-
-func TestRestoreFromStorageRestoresLatestBackup(t *testing.T) {
-	dbFilePath := filepath.Join(t.TempDir(), "dekart.db")
-	st := backupTestStorage{
-		UnsupportedUploadSessionStorage: storage.NewUnsupportedUploadSessionStorage("test"),
-		objects: map[string][]byte{
-			"sqlite-backups/dekart.db_20260601_120000.backup": []byte("old"),
-			"sqlite-backups/dekart.db_20260602_120000.backup": []byte("latest"),
-		},
-	}
-
-	restoreFromStorage(dbFilePath, st, "sqlite-backups")
-
-	got, err := os.ReadFile(dbFilePath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(got) != "latest" {
-		t.Fatalf("expected latest backup, got %q", got)
 	}
 }

--- a/src/server/storage/snowflakestagestorage.go
+++ b/src/server/storage/snowflakestagestorage.go
@@ -57,14 +57,9 @@ func (s *SnowflakeStageStorage) ListObjectsByPrefix(ctx context.Context, stage, 
 		if err := rows.Scan(&fileName, &size, &md5, &lastModified); err != nil {
 			continue
 		}
-		parts := strings.Split(fileName, "/")
-		name := parts[len(parts)-1]
-		if prefix != "" {
-			if idx := strings.Index(fileName, prefix); idx >= 0 {
-				name = fileName[idx:]
-			} else if !strings.HasPrefix(name, prefix) {
-				continue
-			}
+		name := snowflakeStageObjectName(fileName, stageName)
+		if prefix != "" && !strings.HasPrefix(name, prefix) {
+			continue
 		}
 		t := time.Now().UTC()
 		if parsed, err := time.Parse("Mon, 2 Jan 2006 15:04:05 MST", lastModified); err == nil {
@@ -176,6 +171,16 @@ func resolveStageName(stage string) string {
 		stageName = strings.TrimSpace(os.Getenv("DEKART_SNOWFLAKE_STAGE"))
 	}
 	return stageName
+}
+
+// snowflakeStageObjectName converts Snowflake LIST names back to object paths.
+func snowflakeStageObjectName(fileName string, stageName string) string {
+	name := strings.TrimPrefix(strings.TrimSpace(fileName), "@")
+	stagePrefix := strings.Trim(strings.TrimSpace(stageName), "@/") + "/"
+	if idx := strings.Index(strings.ToLower(name), strings.ToLower(stagePrefix)); idx >= 0 {
+		return strings.TrimPrefix(name[idx+len(stagePrefix):], "/")
+	}
+	return strings.TrimPrefix(name, "/")
 }
 
 type removeOnCloseReader struct {

--- a/src/server/storage/snowflakestagestorage_test.go
+++ b/src/server/storage/snowflakestagestorage_test.go
@@ -1,0 +1,34 @@
+package storage
+
+import "testing"
+
+func TestSnowflakeStageObjectNamePreservesObjectPath(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		fileName string
+		want     string
+	}{
+		{
+			name:     "legacy root path",
+			fileName: "DEKART_DEV.PUBLIC.DEKART_DEV/dekart.db_20260601_120000.backup",
+			want:     "dekart.db_20260601_120000.backup",
+		},
+		{
+			name:     "quoted stage marker",
+			fileName: "@DEKART_DEV.PUBLIC.DEKART_DEV/dekart.db_20260601_120000.backup",
+			want:     "dekart.db_20260601_120000.backup",
+		},
+		{
+			name:     "already relative root path",
+			fileName: "dekart.db_20260601_120000.backup",
+			want:     "dekart.db_20260601_120000.backup",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := snowflakeStageObjectName(tc.fileName, "DEKART_DEV.PUBLIC.DEKART_DEV")
+			if got != tc.want {
+				t.Fatalf("expected %q, got %q", tc.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
…me tests

- Implement fingerprinting to skip duplicate backups
- Introduce pruning logic for old backups with configurable limits
- Update backup object naming to support different storage targets
- Add unit tests for Snowflake stage object name handling

## Contributor License Agreement

- [X] I hereby grant to the owners of this project repository a perpetual, worldwide, non-exclusive, royalty-free, irrevocable license to use, reproduce, modify, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute my contributions, in whole or in part, under any licenses, including the GNU Affero General Public License (AGPL) v3.0 and a [Commercial License](https://dekart.xyz/legal/dekart-premium-terms/).
